### PR TITLE
Gateway WiFi Commands

### DIFF
--- a/lager_cli/cli.py
+++ b/lager_cli/cli.py
@@ -32,6 +32,7 @@ from .connect.commands import connect, disconnect
 from .gpio.commands import gpio
 from .openocd.commands import openocd
 from .python.commands import python
+from .wifi.commands import _wifi
 
 def _decode_environment():
     for key in os.environ:
@@ -81,6 +82,7 @@ cli.add_command(disconnect)
 cli.add_command(gpio)
 cli.add_command(openocd)
 cli.add_command(python)
+cli.add_command(_wifi)
 
 def setup_context(ctx, debug, colorize, skip_auth):
     """

--- a/lager_cli/context.py
+++ b/lager_cli/context.py
@@ -306,12 +306,33 @@ class LagerSession(BaseUrlSession):
         url = 'gateway/{}/gpio/hardware-clock'.format(quote(gateway))
         return self.post(url, json={'frequency': frequency})
 
+    def get_wifi_state(self, gateway):
+        """
+            Get the connection state of the specified gateway
+        """
+        url = 'gateway/{}/wifi/state'.format(quote(gateway))
+        return self.get(url)
+
+    def get_wifi_access_points(self, gateway):
+        """
+            Get access points visible to the specified gateway
+        """
+        url = 'gateway/{}/wifi/access-points'.format(quote(gateway))
+        return self.get(url)
+
     def connect_wifi(self, gateway, ssid, password):
         """
             Connect the gateway to a wifi network
         """
         url = 'gateway/{}/wifi/connect'.format(quote(gateway))
         return self.post(url, json={'ssid': ssid, 'password': password})
+
+    def delete_wifi_connection(self, gateway, ssid):
+        """
+            Delete the wifi connection for the specified gateway
+        """
+        url = 'gateway/{}/wifi/delete-connection'.format(quote(gateway))
+        return self.post(url, json={'ssid': ssid})
 
 class LagerContext:  # pylint: disable=too-few-public-methods
     """

--- a/lager_cli/context.py
+++ b/lager_cli/context.py
@@ -306,6 +306,13 @@ class LagerSession(BaseUrlSession):
         url = 'gateway/{}/gpio/hardware-clock'.format(quote(gateway))
         return self.post(url, json={'frequency': frequency})
 
+    def connect_wifi(self, gateway, ssid, password):
+        """
+            Connect the gateway to a wifi network
+        """
+        url = 'gateway/{}/wifi/connect'.format(quote(gateway))
+        return self.post(url, json={'ssid': ssid, 'password': password})
+
 class LagerContext:  # pylint: disable=too-few-public-methods
     """
         Lager Context manager

--- a/lager_cli/wifi/commands.py
+++ b/lager_cli/wifi/commands.py
@@ -35,6 +35,9 @@ def status(ctx, gateway):
 
     session = ctx.obj.session
     resp = session.get_wifi_state(gateway)
+    resp.raise_for_status()
+
+
     click.echo(resp.content, nl=False)
 
 
@@ -50,6 +53,7 @@ def access_points(ctx, gateway):
 
     session = ctx.obj.session
     resp = session.get_wifi_access_points(gateway)
+    resp.raise_for_status()
     click.echo(resp.content, nl=False)
 
 
@@ -68,6 +72,7 @@ def connect(ctx, gateway, ssid, password=''):
     session = ctx.obj.session
     resp = session.connect_wifi(gateway, ssid, password)
     click.echo(resp.content, nl=False)
+    resp.raise_for_status()
 
 
 @_wifi.command()
@@ -84,3 +89,4 @@ def delete_connection(ctx, gateway, ssid):
     session = ctx.obj.session
     resp = session.delete_wifi_connection(gateway, ssid)
     click.echo(resp.content, nl=False)
+    resp.raise_for_status()

--- a/lager_cli/wifi/commands.py
+++ b/lager_cli/wifi/commands.py
@@ -25,7 +25,37 @@ def _wifi():
 
 @_wifi.command()
 @click.pass_context
-@click.option('--gateway', required=False, help='ID of gateway to which DUT is connected')
+@click.option('--gateway', required=False, help='ID of gateway')
+def status(ctx, gateway):
+    """
+        Get the current WiFi Status of the gateway
+    """
+    if gateway is None:
+        gateway = get_default_gateway(ctx)
+
+    session = ctx.obj.session
+    resp = session.get_wifi_state(gateway)
+    click.echo(resp.content, nl=False)
+
+
+@_wifi.command()
+@click.pass_context
+@click.option('--gateway', required=False, help='ID of gateway')
+def access_points(ctx, gateway):
+    """
+        Get WiFi access points visible to the gateway
+    """
+    if gateway is None:
+        gateway = get_default_gateway(ctx)
+
+    session = ctx.obj.session
+    resp = session.get_wifi_access_points(gateway)
+    click.echo(resp.content, nl=False)
+
+
+@_wifi.command()
+@click.pass_context
+@click.option('--gateway', required=False, help='ID of gateway')
 @click.option('--ssid', required=True, help='SSID of the network to connect to')
 @click.option('--password', required=False, help='Password of the network to connect to', default='')
 def connect(ctx, gateway, ssid, password=''):
@@ -37,4 +67,20 @@ def connect(ctx, gateway, ssid, password=''):
 
     session = ctx.obj.session
     resp = session.connect_wifi(gateway, ssid, password)
+    click.echo(resp.content, nl=False)
+
+
+@_wifi.command()
+@click.pass_context
+@click.option('--gateway', required=False, help='ID of gateway')
+@click.option('--ssid', required=True, help='SSID of the network to delete')
+def delete_connection(ctx, gateway, ssid):
+    """
+        Delete the specified network from the gateway
+    """
+    if gateway is None:
+        gateway = get_default_gateway(ctx)
+
+    session = ctx.obj.session
+    resp = session.delete_wifi_connection(gateway, ssid)
     click.echo(resp.content, nl=False)

--- a/lager_cli/wifi/commands.py
+++ b/lager_cli/wifi/commands.py
@@ -1,0 +1,40 @@
+"""
+    lager.wifi.commands
+
+    Commands for controlling the wifi network
+"""
+
+import sys
+import math
+import click
+from ..context import get_default_gateway
+from ..status import run_job_output
+from ..config import read_config_file
+
+import click
+from ..context import get_default_gateway
+
+
+@click.group(name='wifi')
+def _wifi():
+    """
+        Lager wifi commands
+    """
+    pass
+
+
+@_wifi.command()
+@click.pass_context
+@click.option('--gateway', required=False, help='ID of gateway to which DUT is connected')
+@click.option('--ssid', required=True, help='SSID of the network to connect to')
+@click.option('--password', required=False, help='Password of the network to connect to', default='')
+def connect(ctx, gateway, ssid, password=''):
+    """
+        Connect the gateway to a new network
+    """
+    if gateway is None:
+        gateway = get_default_gateway(ctx)
+
+    session = ctx.obj.session
+    resp = session.connect_wifi(gateway, ssid, password)
+    click.echo(resp.content, nl=False)


### PR DESCRIPTION
This PR adds commands to control Comitup on the gateway using `dbus`. This goes along with PR https://github.com/lagerdata/lager/pull/68 containing changes to the controller and the lagerdata gateway v1 API. 

The new commands are outlined as follows (`lager wifi`):

```
Usage: lager wifi [OPTIONS] COMMAND [ARGS]...

  Lager wifi commands

Options:
  --help  Show this message and exit.

Commands:
  access-points      Get WiFi access points visible to the gateway
  connect            Connect the gateway to a new network
  delete-connection  Delete the specified network from the gateway
  status             Get the current WiFi Status of the gateway
```
